### PR TITLE
files found in Settings.container_env_var_dir are added as env vars to all containers

### DIFF
--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -356,7 +356,13 @@ class DockerManager < ContainerManager
   end
 
   def build_container_envvar(guid)
-    ["NAME=#{container_name(guid)}"]
+    base = ["NAME=#{container_name(guid)}"]
+    Dir[File.join(Settings.container_env_var_dir, "*")].each do |env_var_file|
+      env_var_name = File.basename(env_var_file)
+      env_var_value = File.read(env_var_file).strip
+      base << "#{env_var_name}=#{env_var_value}"
+    end
+    base
   end
 
   def build_parameters_envvars(parameters = {})

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,6 +18,7 @@ defaults: &defaults
   host_directory: '/var/vcap/store/cf-containers-broker/'
   max_containers: 0
   allocate_docker_host_ports: true
+  container_env_var_dir: '/var/vcap/store/cf-containers-broker/envdir'
 
   services:
     - id: '2fd814ac-d1f7-4d4a-a4f7-d386cd8fd8e3'

--- a/spec/models/docker_manager_spec.rb
+++ b/spec/models/docker_manager_spec.rb
@@ -463,6 +463,27 @@ describe DockerManager do
         end
       end
 
+      context 'when there are container env vars in files' do
+        let(:tmp_envdir) { "/tmp/container_env_var_dir" }
+        let(:env_vars) { ['USER=MY-USER', "NAME=#{container_name}", 'lower_case=lower-value', 'UPPER_CASE=1234'] }
+
+        before do
+          FileUtils.rm_rf(tmp_envdir)
+          FileUtils.mkdir_p(tmp_envdir)
+          expect(Settings).to receive(:container_env_var_dir).and_return(tmp_envdir)
+        end
+
+        it 'should load files into container env vars' do
+          File.open(File.join(tmp_envdir, "lower_case"), "w") { |f| f << "lower-value\n" }
+          File.open(File.join(tmp_envdir, "UPPER_CASE"), "w") { |f| f << "1234" }
+
+          expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
+          expect(container).to receive(:start).with(container_start_opts)
+          expect(container).to receive(:json).and_return(container_state)
+          subject.create(guid)
+        end
+      end
+
       context 'when there are service arbitrary parameters' do
         let(:parameters) { { 'foo' => 'bar', 'bar' => 'foo' } }
         let(:env_vars) { ['USER=MY-USER', "NAME=#{container_name}", 'foo=bar', 'bar=foo'] }

--- a/spec/models/docker_manager_spec.rb
+++ b/spec/models/docker_manager_spec.rb
@@ -484,6 +484,19 @@ describe DockerManager do
         end
       end
 
+      context 'when badly configured Settings.container_env_var_dir' do
+        before do
+          expect(Settings).to receive(:container_env_var_dir).and_return("/path/not/exists")
+        end
+
+        it 'should not fail if Settings.container_env_var_dir does not exist' do
+          expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
+          expect(container).to receive(:start).with(container_start_opts)
+          expect(container).to receive(:json).and_return(container_state)
+          subject.create(guid)
+        end
+      end
+
       context 'when there are service arbitrary parameters' do
         let(:parameters) { { 'foo' => 'bar', 'bar' => 'foo' } }
         let(:env_vars) { ['USER=MY-USER', "NAME=#{container_name}", 'foo=bar', 'bar=foo'] }


### PR DESCRIPTION
If `/var/vcap/store/cf-containers-broker/envdir/GUID` contained `xxxxx`, then each container will include an environment variable `GUID` with the value `xxxxx`.