### PR TITLE
Tag all log entries with the service instance ID

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,10 @@ gem 'nats'
 gem 'sass-rails'
 gem 'docker-api'
 
+
 group :production do
   gem 'unicorn'
+  gem 'lograge'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,10 @@ GEM
     listen (3.0.4)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
+    lograge (0.3.4)
+      actionpack (>= 3)
+      activesupport (>= 3)
+      railties (>= 3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.9)
@@ -209,6 +213,7 @@ PLATFORMS
 DEPENDENCIES
   docker-api
   guard-rails
+  lograge
   nats
   omniauth-uaa-oauth2!
   rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,6 +41,9 @@ CfContainersBroker::Application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
   config.lograge.enabled = true
 
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  # config.log_formatter = ::Logger::Formatter.new
+
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -61,6 +64,4 @@ CfContainersBroker::Application.configure do
   # Disable automatic flushing of the log to improve performance.
   # config.autoflush_log = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,6 +39,7 @@ CfContainersBroker::Application.configure do
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.lograge.enabled = true
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,8 @@ CfContainersBroker::Application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
+  # 1. service instance ID
+  config.log_tags = [ lambda { |r| if r.env['REQUEST_PATH'] =~ %r{/service_instances/([^/]+)}; $1; else $1; end } ]
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)


### PR DESCRIPTION
Allows search of logs for anything associated with a service instance ID:

![image](https://cloud.githubusercontent.com/assets/108/11319886/b64d0f26-903b-11e5-8a7e-810b6205aec4.png)

Also, the timestamp has been removed - assuming that production logging will go to a log aggregator that manages its own timestamp.