### PR TITLE
Workaround bug in api of docker 1.10.0

### DIFF
--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -118,7 +118,7 @@ class DockerManager < ContainerManager
   def fetch_image
     Rails.logger.info("Fetching Docker image `#{image}:#{tag}'...")
     begin
-      Docker::Image.create('fromImage' => image, 'tag' => tag)
+      Docker::Image.create('fromImage' => "#{image}:#{tag}")
     rescue Exception => e
       Rails.logger.error("+-> Cannot fetch Docker image `#{image}:#{tag}': #{e.inspect}")
       raise Exceptions::BackendError, "Cannot fetch Docker image `#{image}:#{tag}"

--- a/spec/models/docker_manager_spec.rb
+++ b/spec/models/docker_manager_spec.rb
@@ -581,14 +581,14 @@ describe DockerManager do
 
   describe '#fetch_image' do
     it 'should fetch the image' do
-      expect(Docker::Image).to receive(:create).with('fromImage' => 'my-image', 'tag' => 'latest')
+      expect(Docker::Image).to receive(:create).with('fromImage' => 'my-image:latest')
       subject.fetch_image
     end
 
     context 'when it cannot fetch the image' do
       it 'should raise an Exception' do
         expect(Docker::Image).to receive(:create)
-                                 .with('fromImage' => 'my-image', 'tag' => 'latest')
+                                 .with('fromImage' => 'my-image:latest')
                                  .and_raise(Exceptions::NotFound)
         expect do
           subject.fetch_image


### PR DESCRIPTION
After upgrading to docker 1.10.0 from [docker-boshrelease v24](https://github.com/cloudfoundry-community/docker-boshrelease/releases/tag/v24) the script `bin/fetch_container_images` is throwing an exception. This workaround fixes the issue and is also backwards compatible. 

See https://github.com/swipely/docker-api/issues/369 for more information.