### PR TITLE
Stop containers instead of killing them on update/delete

### DIFF
--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -86,7 +86,7 @@ class DockerManager < ContainerManager
       raise Exceptions::NotFound, "Docker container `#{container_name(guid)}' not found"
     end
     port_bindings = container.json['HostConfig']['PortBindings']
-    container.kill
+    container.stop
     container.remove(v: true, force: true)
 
     container_create_opts = create_options(guid, parameters)
@@ -108,7 +108,7 @@ class DockerManager < ContainerManager
   def destroy(guid)
     Rails.logger.info("Destroying Docker container `#{container_name(guid)}'...")
     if container = find(guid)
-      container.kill
+      container.stop
       container.remove(v: true, force: true)
       destroy_volumes(guid)
     else

--- a/spec/models/docker_manager_spec.rb
+++ b/spec/models/docker_manager_spec.rb
@@ -517,11 +517,11 @@ describe DockerManager do
       let(:binds) { ["/tmp/#{container_name}#{persistent_volume}:#{persistent_volume}"] }
       let(:port_bindings) { {"5432/tcp"=>[{"HostIp"=>"", "HostPort"=>"55555"}]} }
 
-      it 'should kill then recreate the container with existing persistent data' do
+      it 'should stop then recreate the container with existing persistent data' do
         expect(Docker::Container).to receive(:get).with(container_name).and_return(container)
         expect(container).to receive(:json).and_return({
           'HostConfig' => {'PortBindings' => port_bindings}})
-        expect(container).to receive(:kill)
+        expect(container).to receive(:stop)
         expect(container).to receive(:remove).with(v: true, force: true)
 
         expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
@@ -549,9 +549,9 @@ describe DockerManager do
   end
 
   describe '#destroy' do
-    it 'should kill and remove the container and delete any persistent data' do
+    it 'should stop and remove the container and delete any persistent data' do
       expect(Docker::Container).to receive(:get).with(container_name).and_return(container)
-      expect(container).to receive(:kill)
+      expect(container).to receive(:stop)
       expect(container).to receive(:remove).with(v: true, force: true)
       expect(Settings).to receive(:host_directory).and_return('/tmp')
       expect(FileUtils).to receive(:remove_entry_secure).with("/tmp/#{container_name}", true)
@@ -572,7 +572,7 @@ describe DockerManager do
 
       it 'should not delete any persistent data' do
         expect(Docker::Container).to receive(:get).with(container_name).and_return(container)
-        expect(container).to receive(:kill)
+        expect(container).to receive(:stop)
         expect(container).to receive(:remove).with(v: true, force: true)
         expect(Settings).to_not receive(:host_directory)
         expect(FileUtils).to_not receive(:remove_entry_secure)


### PR DESCRIPTION
Stop sends the SIGTERM signal which gives the running container the
possibility to catch the signal and run a cleanup script.

Closes #55 