### PR TITLE
Compatibility with Docker 1.12 API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM frodenas/ruby
+FROM ruby:2.3.1
 MAINTAINER Ferran Rodenas <frodenas@gmail.com>
 
 # Add application code
@@ -36,4 +36,3 @@ EXPOSE 80
 
 # Expose the configuration and logs directories
 VOLUME ["/config", "/app/log"]
-

--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -255,9 +255,14 @@ class DockerManager < ContainerManager
   end
 
   def validate_docker_remote_api
-    api_version = Docker.version.fetch('ApiVersion', '0')
-    # Swarm returns API version with wrong key APIVersion instead of ApiVersion, so until
-    # https://github.com/docker/swarm/issues/687 is solved and released, work around this
+    api_version = 0
+    begin
+      api_version = Docker.version.fetch('ApiVersion', '0')
+    rescue
+      api_version = 0
+    end
+      # Swarm returns API version with wrong key APIVersion instead of ApiVersion, so until
+      # https://github.com/docker/swarm/issues/687 is solved and released, work around this
     if api_version == '0'
       api_version = Docker.version.fetch('APIVersion', '0')
     end


### PR DESCRIPTION
After upgrading to Docker v1.12 the broker raised exceptions. This is a quick fix for the exception thrown through Docker v1.12 API incompatibility. Also needed ruby 2.3.1 for successfully building docker image.
