### PR TITLE
dashboard_client.redirect_uri is generated from external_host + ssl_enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ branches:
     - master
 
 rvm:
-  - 2.0.0
-  - 2.1.0
   - 2.2.0
+  - 2.3.3
 
 bundler_args: --deployment --without development
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -25,6 +25,7 @@ class Service
     @plans       = attrs.fetch('plans')
     @plan_updateable  = attrs.fetch('plan_updateable', true) || true
     @dashboard_client = attrs.fetch('dashboard_client', {}) || {}
+    populate_others
   end
 
   def to_hash
@@ -54,6 +55,14 @@ class Service
 
     unless missing_keys.empty?
       raise Exceptions::ArgumentError, "Missing Service parameters: #{missing_keys.join(', ')}"
+    end
+  end
+
+  def populate_others
+    base_url = Settings.external_host
+    protocol = Settings.ssl_enabled ? 'https' : 'http'
+    unless dashboard_client.empty?
+      dashboard_client['redirect_uri'] = "#{protocol}://#{base_url}/manage/auth/cloudfoundry/callback"
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,7 +39,6 @@ defaults: &defaults
       dashboard_client:
         id: 'p-postgresql93-client'
         secret: 'p-postgresql93-secret'
-        redirect_uri: 'http://127.0.0.1:3000/manage/auth/cloudfoundry/callback'
       plans:
         - id: '1a0efffc-eb45-4bf8-8ee3-a3c1a9a53151'
           name: 'free'

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -27,7 +27,6 @@ describe Service do
     'dashboard_client' => {
       'id'           => 'client-id',
       'secret'       => 'client-secret',
-      'redirect_uri' => 'https://broker.10.0.0.1.xip.io/manage/auth/cloudfoundry/callback',
     },
   )
   end
@@ -49,7 +48,7 @@ describe Service do
       expect(service.dashboard_client).to eql({
         'id'           => 'client-id',
         'secret'       => 'client-secret',
-        'redirect_uri' => 'https://broker.10.0.0.1.xip.io/manage/auth/cloudfoundry/callback',
+        'redirect_uri' => 'http://containers.vcap.me/manage/auth/cloudfoundry/callback',
       })
     end
 
@@ -115,7 +114,7 @@ describe Service do
       expect(service_hash.fetch('dashboard_client')).to eq({
         'id'           => 'client-id',
         'secret'       => 'client-secret',
-        'redirect_uri' => 'https://broker.10.0.0.1.xip.io/manage/auth/cloudfoundry/callback',
+        'redirect_uri' => 'http://containers.vcap.me/manage/auth/cloudfoundry/callback',
       })
     end
   end


### PR DESCRIPTION
Towards supporting bosh2, instead of hard coded `dashboard.redirect_uri` within each service, we will generate it from `Settings.external_host` and `Settings.ssl_enabled`