### PR TITLE
support ruby v2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
 rvm:
   - 2.2.0
   - 2.3.3
+  - 2.4.1
 
 bundler_args: --deployment --without development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     hashdiff (0.3.0)
     hashie (3.4.4)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     kgio (2.10.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -224,4 +224,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.11.2
+   1.14.3


### PR DESCRIPTION
https://travis-ci.org/cloudfoundry-community/cf-containers-broker/jobs/216178959
```
bundler: failed to load command: rspec (/home/travis/build/cloudfoundry-community/cf-containers-broker/vendor/bundle/ruby/2.4.0/bin/rspec)
SystemStackError: stack level too deep
  /home/travis/build/cloudfoundry-community/cf-containers-broker/vendor/bundle/ruby/2.4.0/gems/activesupport-4.2.6/lib/active_support/core_ext/numeric/conversions.rb:131:in `block (2 levels) in <class:Numeric>'
```