### PR TITLE
Don't emit an empty `dashboard_client` if not specified in config

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -29,7 +29,7 @@ class Service
   end
 
   def to_hash
-    {
+    rv = {
       'id'               => id,
       'name'             => name,
       'description'      => description,
@@ -39,8 +39,14 @@ class Service
       'requires'         => requires,
       'plans'            => plans.map(&:to_hash),
       'plan_updateable'  => plan_updateable,
-      'dashboard_client' => dashboard_client,
     }
+
+    # Do not return even a empty map unless we have a value
+    # (else subway deserialization/serialization will add them it)
+    unless dashboard_client.empty?
+          rv['dashboard_client'] = dashboard_client
+    end
+    rv
   end
 
   private

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -119,3 +119,33 @@ describe Service do
     end
   end
 end
+
+describe Service do
+  let(:subject) { described_class }
+  let(:plan) { double('Plan', to_hash: 'plan-hash') }
+  let(:service) do
+    described_class.build(
+    'id'               => 'service_id',
+    'name'             => 'service_name',
+    'description'      => 'service_description',
+    'bindable'         => false,
+    'plans'            => [
+      double('Plan')
+    ],
+    'plan_updateable'  => true,
+  )
+  end
+
+  before do
+    allow(Plan).to receive(:build).and_return(plan)
+  end
+
+  describe '#to_hash' do
+    it 'contains the correct values' do
+      service_hash = service.to_hash
+
+      expect(service_hash.fetch('id')).to eq('service_id')
+      expect(service_hash.has_value?('dashboard_client')).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Else, the `broker-registrar` errand will later fail, since CF expects `dashboard_client`, if present, to contain actual valid parameters.

Even though this component won't emit the empty parameters within, the subway component (which uses Go to round-trip these JSONs) will detect the empty map, and then emit a more filled out version, albeit with completed names but not values, which is possibly worse.

In any case, the `dashboard_client` is optional, so we shouldn't output it if we have no values.

(be gentle, I haven't written Ruby code before)